### PR TITLE
Fix crash in PIF generation

### DIFF
--- a/Fixtures/Miscellaneous/Plugins/BinaryTargetExePlugin/Dependency/MyBinaryTargetExeArtifactBundle.artifactbundle/info.json
+++ b/Fixtures/Miscellaneous/Plugins/BinaryTargetExePlugin/Dependency/MyBinaryTargetExeArtifactBundle.artifactbundle/info.json
@@ -1,0 +1,19 @@
+{
+    "schemaVersion": "1.0",
+    "artifacts": {
+        "mytool": {
+            "type": "executable",
+            "version": "1.2.3",
+            "variants": [
+                {
+                    "path": "mytool-macos/mytool",
+                    "supportedTriples": ["x86_64-apple-macosx", "arm64-apple-macosx"]
+                },
+                {
+                    "path": "mytool-linux/mytool",
+                    "supportedTriples": ["x86_64-unknown-linux-gnu"]
+                }
+            ]
+        }
+    }
+}

--- a/Fixtures/Miscellaneous/Plugins/BinaryTargetExePlugin/Dependency/MyBinaryTargetExeArtifactBundle.artifactbundle/mytool-linux/mytool
+++ b/Fixtures/Miscellaneous/Plugins/BinaryTargetExePlugin/Dependency/MyBinaryTargetExeArtifactBundle.artifactbundle/mytool-linux/mytool
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+print_usage() {
+    echo "usage: ${0##*/} [--verbose] <in> <out>"
+}
+
+# Parse arguments until we find '--' or an argument that isn't an option.
+until [ $# -eq 0 ]
+do
+    case "$1" in
+        --verbose) verbose=1; shift;;
+        --) shift; break;;
+        -*) echo "unknown option: ${1}"; print_usage; exit 1; shift;;
+        *) break;;
+    esac
+done
+
+# Print usage and leave if we don't have exactly two arguments.
+if [ $# -ne 2 ]; then
+    print_usage
+    exit 1
+fi
+
+# For our sample tool we just copy from one to the other.
+if [ $verbose != 0 ]; then
+    echo "[${0##*/}-linux] '$1' '$2'"
+fi
+
+cp "$1" "$2"

--- a/Fixtures/Miscellaneous/Plugins/BinaryTargetExePlugin/Dependency/MyBinaryTargetExeArtifactBundle.artifactbundle/mytool-macos/mytool
+++ b/Fixtures/Miscellaneous/Plugins/BinaryTargetExePlugin/Dependency/MyBinaryTargetExeArtifactBundle.artifactbundle/mytool-macos/mytool
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+print_usage() {
+    echo "usage: ${0##*/} [--verbose] <in> <out>"
+}
+
+# Parse arguments until we find '--' or an argument that isn't an option.
+until [ $# -eq 0 ]
+do
+    case "$1" in
+        --verbose) verbose=1; shift;;
+        --) shift; break;;
+        -*) echo "unknown option: ${1}"; print_usage; exit 1; shift;;
+        *) break;;
+    esac
+done
+
+# Print usage and leave if we don't have exactly two arguments.
+if [ $# -ne 2 ]; then
+    print_usage
+    exit 1
+fi
+
+# For our sample tool we just copy from one to the other.
+if [ $verbose != 0 ]; then
+    echo "[${0##*/}-macosx] '$1' '$2'"
+fi
+
+cp "$1" "$2"

--- a/Fixtures/Miscellaneous/Plugins/BinaryTargetExePlugin/Package.swift
+++ b/Fixtures/Miscellaneous/Plugins/BinaryTargetExePlugin/Package.swift
@@ -1,0 +1,38 @@
+// swift-tools-version: 5.6
+import PackageDescription
+
+let package = Package(
+    name: "MyBinaryTargetExePlugin",
+
+    products: [
+        .executable(
+            name: "MyPluginExe",
+            targets: ["MyPluginExe"]
+        ),
+        .plugin(
+            name: "MyPlugin",
+            targets: ["MyPlugin"]
+        ),
+        .executable(
+            name: "MyBinaryTargetExe",
+            targets: ["MyBinaryTargetExeArtifactBundle"]
+        ),
+    ],
+    targets: [
+        .executableTarget(
+            name: "MyPluginExe",
+            dependencies: [],
+            exclude: [],
+        ),
+
+        .plugin(
+            name: "MyPlugin",
+            capability: .buildTool(),
+            dependencies: ["MyPluginExe", "MyBinaryTargetExeArtifactBundle"]
+        ),
+        .binaryTarget(
+            name: "MyBinaryTargetExeArtifactBundle",
+            path: "Dependency/MyBinaryTargetExeArtifactBundle.artifactbundle"
+        ),
+    ]
+)

--- a/Fixtures/Miscellaneous/Plugins/BinaryTargetExePlugin/Plugins/MyPlugin/plugin.swift
+++ b/Fixtures/Miscellaneous/Plugins/BinaryTargetExePlugin/Plugins/MyPlugin/plugin.swift
@@ -1,0 +1,9 @@
+import PackagePlugin
+
+@main
+struct MyPlugin: BuildToolPlugin {
+    
+    func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
+        print("Hello from MyPlugin!")
+    }
+}

--- a/Fixtures/Miscellaneous/Plugins/BinaryTargetExePlugin/Sources/MyPluginExe/main.swift
+++ b/Fixtures/Miscellaneous/Plugins/BinaryTargetExePlugin/Sources/MyPluginExe/main.swift
@@ -1,0 +1,1 @@
+print("It's Me MyPluginExe\n")

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
@@ -523,8 +523,8 @@ extension PackageGraph.ResolvedModule {
             // triple will be '.tools' while the target we want to depend on will have a build triple of '.destination'.
             // See for more details:
             // https://github.com/swiftlang/swift-package-manager/commit/b22168ec41061ddfa3438f314a08ac7a776bef7a.
-            return mainModuleProduct.mainModule!.packageIdentity == self.packageIdentity &&
-                mainModuleProduct.mainModule!.name == self.name
+            return mainModule.packageIdentity == self.packageIdentity &&
+                mainModule.name == self.name
             // Intentionally ignore the build triple!
         }
     }

--- a/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
+++ b/Sources/SwiftBuildSupport/PackagePIFBuilder+Helpers.swift
@@ -513,6 +513,12 @@ extension PackageGraph.ResolvedModule {
 
     func productRepresentingDependencyOfBuildPlugin(in mainModuleProducts: [ResolvedProduct]) -> ResolvedProduct? {
         mainModuleProducts.only { (mainModuleProduct: ResolvedProduct) -> Bool in
+            // Handle binary-only executable products that don't have a main module, i.e. binaryTarget
+            guard let mainModule = mainModuleProduct.mainModule else {
+                return mainModuleProduct.type == .executable &&
+                    mainModuleProduct.modules.only?.type == .binary &&
+                    mainModuleProduct.modules.only?.name == self.name
+            }
             // NOTE: We can't use the 'id' here as we need to explicitly ignore the build triple because our build
             // triple will be '.tools' while the target we want to depend on will have a build triple of '.destination'.
             // See for more details:


### PR DESCRIPTION
Fix a crash when unwrapping an optional 'mainModule' of a module.
In the case where a plugin has a dependency on a 'binaryTarget' there is no main module.

This only presents itself when you have defined the binaryTarget as
both a product and target.

-  Update method that determines plugin dependencies to handle binaryTarget types explicitly.
-  Add a PIF generation test that captures this behavior.